### PR TITLE
Remove need for regenerator runtime

### DIFF
--- a/examples/runkit.js
+++ b/examples/runkit.js
@@ -1,6 +1,3 @@
-// requires ployfill for ES7 async/await
-require("babel-polyfill");
-
 const corenlp = require("corenlp");
 const CoreNLP = corenlp.default; // convenient when not using `import`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
       "dev": true
     },
+    "acorn-es7-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
+      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
+      "dev": true
+    },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -716,21 +722,10 @@
         "babel-types": "6.25.0"
       }
     },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.25.0",
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.10.5"
-      }
-    },
     "babel-preset-env": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -763,48 +758,6 @@
         "browserslist": "2.3.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
-    },
-    "babel-preset-es2017": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz",
-      "integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1"
       }
     },
     "babel-register": {
@@ -1888,6 +1841,16 @@
       "requires": {
         "chalk": "1.1.3",
         "time-stamp": "1.1.0"
+      }
+    },
+    "fast-async": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fast-async/-/fast-async-6.3.0.tgz",
+      "integrity": "sha512-db5wfZ2+cv15bMfXbH9axCslxsTrhquGfkZiVhmUn2gFdNRnp8sweMSH1/9+M0+fHVHhHZBwll3SqCiNlcQhzg==",
+      "dev": true,
+      "requires": {
+        "nodent-compiler": "3.1.5",
+        "nodent-runtime": "3.2.0"
       }
     },
     "fast-deep-equal": {
@@ -4101,6 +4064,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.0.tgz",
       "integrity": "sha512-t1V2RFiaTavaW3jtQO0A2nok6k7/Gghuvx2rjvICuT0B0dYaObBQ4U0xHL+ZTPFZodt1LMYG2Vi2nypfz4/AJg=="
+    },
+    "nodent-compiler": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/nodent-compiler/-/nodent-compiler-3.1.5.tgz",
+      "integrity": "sha512-Istg796un2lALiy/eFNnLbAEMovQqrtpVqXVY8PKs6ycsyBbK480D55misJBQ1QxvstcJ7Hk9xbSVkV8lIi+tg==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-es7-plugin": "1.1.7",
+        "source-map": "0.5.6"
+      }
+    },
+    "nodent-runtime": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.2.0.tgz",
+      "integrity": "sha512-vpc9vNZmLiTgQO/0ecoX0rogUSikHRj6hPTCO4pW0cJQiozdhhfxsb3TfNi9pzrpNVG71c7oXWRocbfdvkuhWw==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -6674,12 +6654,6 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6706,6 +6680,12 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublish": "npm run lint && npm run test && npm run compile",
     "lint": "eslint 'src/**/*.js' 'test/*.js'",
     "lint:fix": "npm run lint -- --fix",
-    "test": "nyc --reporter=html --reporter=text mocha --require babel-polyfill test/setup.js --sort 'src/**/*.spec.js' --compilers js:babel-core/register --timeout 30000",
+    "test": "nyc --reporter=html --reporter=text mocha test/setup.js --sort 'src/**/*.spec.js' --compilers js:babel-core/register --timeout 30000",
     "test:watch": "npm run test -- --watch",
     "doc": "DEBUG=gulp-jsdoc3 gulp doc"
   },
@@ -41,28 +41,36 @@
   },
   "homepage": "https://github.com/gerardobort/node-corenlp#readme",
   "runkitExampleFilename": "examples/runkit.js",
+  "engines": {
+    "node": ">= 6"
+  },
   "babel": {
     "plugins": [
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      ["fast-async", {
+        "spec":true
+      }]
     ],
     "presets": [
-      "es2015",
-      "es2017"
+      ["env", {
+        "targets": {
+          "node": "6"
+        },
+        "exclude": ["transform-regenerator"]
+      }]
     ]
   },
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-polyfill": "^6.23.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2017": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.1",
     "cz-conventional-changelog": "^2.0.0",
     "docdash": "^0.4.0",
     "eslint": "^4.5.0",
     "eslint-config-airbnb-base": "^11.3.1",
     "eslint-plugin-import": "^2.7.0",
+    "fast-async": "^6.3.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",
     "gulp-clean": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -47,17 +47,25 @@
   "babel": {
     "plugins": [
       "transform-object-rest-spread",
-      ["fast-async", {
-        "spec":true
-      }]
+      [
+        "fast-async",
+        {
+          "spec": true
+        }
+      ]
     ],
     "presets": [
-      ["env", {
-        "targets": {
-          "node": "6"
-        },
-        "exclude": ["transform-regenerator"]
-      }]
+      [
+        "env",
+        {
+          "targets": {
+            "node": "6"
+          },
+          "exclude": [
+            "transform-regenerator"
+          ]
+        }
+      ]
     ]
   },
   "devDependencies": {

--- a/src/connector/connector-server.js
+++ b/src/connector/connector-server.js
@@ -44,8 +44,8 @@ class ConnectorServer {
      * The conenctor should support extensibility to special tools:
      * - For example, Semgrex is an utility that runs in a separate url Hanlder
      *   in StanfordCoreNLPServer
-     *   This url is /semgrex, and apart of the normal options, it expects the 
-     *   query-string `pattern` as a must.  This `pattern` option is taken here from 
+     *   This url is /semgrex, and apart of the normal options, it expects the
+     *   query-string `pattern` as a must.  This `pattern` option is taken here from
      *   the options object, form the key `semgrex.pattern`.
      */
     if (utility) {

--- a/src/simple/annotator.js
+++ b/src/simple/annotator.js
@@ -86,7 +86,7 @@ class Annotator {
   }
 
   /**
-   * Get an object of all the Annotator options including the current and all its 
+   * Get an object of all the Annotator options including the current and all its
    * dependencies, prefixed by the annotator names
    * This is useful to fulfill the options params in CoreNLP API properties.
    * @return {Array.<string>} pipelineOptions

--- a/src/simple/document.js
+++ b/src/simple/document.js
@@ -55,7 +55,7 @@ class Document extends Annotable {
 
   /**
    * @todo Missing implementation
-   * @requires {Promise<DeterministicCorefAnnotator>} dcoref 
+   * @requires {Promise<DeterministicCorefAnnotator>} dcoref
    * @see https://stanfordnlp.github.io/CoreNLP/dcoref.html
    * @returns {undefined}
    */

--- a/src/simple/governor.js
+++ b/src/simple/governor.js
@@ -73,7 +73,7 @@ class Governor {
 
   /**
    * Get an instance of Governor from a given JSON
-   * 
+   *
    * @todo It is not possible to properly generate a Governor from a GovernorJSON
    *       the Governor requires references to the Token instances in order to work
    * @param {GovernorJSON} data - The token data, as returned by CoreNLP API service

--- a/src/simple/token.js
+++ b/src/simple/token.js
@@ -22,7 +22,7 @@ import Annotable from './annotable';
  * by language provided by this library.  It's only helpful for analysis and study.  The
  * data was collected from different documentation resources on the Web.
  * The PosInfo may vary depending on the POS annotation types used, for example, CoreNLP
- * for Spanish uses custom POS tags developed by Stanford, but this can also be changed 
+ * for Spanish uses custom POS tags developed by Stanford, but this can also be changed
  * to Universal Dependencies, which uses different tags.
  * @property {string} group
  * @property {string} tag


### PR DESCRIPTION
Regenerator is annoying for consumers of this package. This is unnecessary if async/await is transpiled down to plain promises.

**Summary of changes**
- Fix linting
- Replace `2015`/`2017` presets (deprecated) with `babel-preset-env`, targeting Node 6+
- Add Node.js 6+ to engines field to package.json
- Use `fast-async` plugin to transpile `async/await` down to promises
  
 This is technically a breaking change, as Node <6 would no longer be supported.