### PR TITLE
feat(corefs): adding corefs annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ CoreNLP
       ParserAnnotator             # https://stanfordnlp.github.io/CoreNLP/parse.html
       DependencyParseAnnotator    # https://stanfordnlp.github.io/CoreNLP/depparse.html
       RelationExtractorAnnotator  # https://stanfordnlp.github.io/CoreNLP/relation.html
-      DeterministicCorefAnnotator # https://stanfordnlp.github.io/CoreNLP/coref.html
+      CorefAnnotator              # https://stanfordnlp.github.io/CoreNLP/coref.html
       SentimentAnnotator          # https://stanfordnlp.github.io/CoreNLP/sentiment.html - TODO
       RelationExtractorAnnotator  # https://stanfordnlp.github.io/CoreNLP/relation.html - TODO
       NaturalLogicAnnotator       # https://stanfordnlp.github.io/CoreNLP/natlog.html - TODO

--- a/examples/corefs.js
+++ b/examples/corefs.js
@@ -1,0 +1,36 @@
+// NOTE: run with babel-node
+import path from 'path';
+import CoreNLP, { Properties, Pipeline, ConnectorServer } from '../src';
+
+const props = new Properties();
+props.setProperty('annotators', 'tokenize,ssplit,coref');
+const doc = new CoreNLP.simple.Document(`
+  George is a good person. He is really smart. I heard he is also a great son.
+  Lisa is instead a sad girl, I never saw her happy.
+`);
+const pipeline = new Pipeline(props, 'English');
+
+pipeline.annotate(doc)
+  .then(doc => {
+    const corefChains = doc.corefs();
+    corefChains.forEach(chain => {
+      console.log('representative ->', chain.representative().token().word());
+      chain.nonRepresentatives().forEach(mention => {
+        console.log(' ref ->', mention.token().word(), mention.gender(), mention.number());
+      });
+    });
+  })
+  .catch(err => {
+    console.log('err', err);
+  });
+
+/*
+OUTPUT:
+representative -> George
+ ref -> He MALE SINGULAR
+ ref -> he MALE SINGULAR
+representative -> Lisa
+ ref -> her FEMALE SINGULAR
+representative -> I
+ ref -> I UNKNOWN SINGULAR
+*/

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import ParserAnnotator from './simple/annotator/parse';
 import DependencyParseAnnotator from './simple/annotator/depparse';
 import RelationExtractorAnnotator from './simple/annotator/relation';
 import RegexNERAnnotator from './simple/annotator/regexner';
+import CorefAnnotator from './simple/annotator/coref';
 import Tree from './util/tree';
 import _Properties from './properties';
 import _Pipeline from './pipeline';
@@ -56,6 +57,7 @@ export default {
       DependencyParseAnnotator,
       RelationExtractorAnnotator,
       RegexNERAnnotator,
+      CorefAnnotator,
     },
   },
   /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -18,6 +18,7 @@ import ParserAnnotator from './simple/annotator/parse';
 import DependencyParseAnnotator from './simple/annotator/depparse';
 import RelationExtractorAnnotator from './simple/annotator/relation';
 import RegexNERAnnotator from './simple/annotator/regexner';
+import CorefAnnotator from './simple/annotator/coref';
 import Tree from './util/tree';
 
 describe('CoreNLP Library entry point', () => {
@@ -71,6 +72,7 @@ describe('CoreNLP Library entry point', () => {
             DependencyParseAnnotator,
             RelationExtractorAnnotator,
             RegexNERAnnotator,
+            CorefAnnotator,
           });
         });
       });

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -10,6 +10,7 @@ import parse from './simple/annotator/parse';
 import depparse from './simple/annotator/depparse';
 import relation from './simple/annotator/relation';
 import regexner from './simple/annotator/regexner';
+import coref from './simple/annotator/coref';
 import Document from './simple/document';
 
 import {
@@ -28,6 +29,7 @@ const ANNOTATORS_BY_KEY = {
   depparse,
   relation,
   regexner,
+  coref,
 };
 
 const LANGUAGE_TO_ISO2 = {

--- a/src/simple/annotator/coref.js
+++ b/src/simple/annotator/coref.js
@@ -1,0 +1,32 @@
+import Annotator from '../annotator';
+import TokenizerAnnotator from './tokenize';
+import WordsToSentenceAnnotator from './ssplit';
+
+/**
+ * @class
+ * @classdesc Class representing an CorefAnnotator.
+ * @extends Annotator
+ * @memberof CoreNLP/simple/annotator
+ * @requires tokenize, ssplit, coref
+ * @see {@link https://stanfordnlp.github.io/CoreNLP/coref.html|CorefAnnotator}
+ */
+class CorefAnnotator extends Annotator {
+  /**
+   * Create an Annotator
+   * @param {Object} [options] a key-value map of options, without the annotator prefix
+   */
+  constructor(options = {}) {
+    super(
+      'coref',
+      {
+        ...options,
+      },
+      [
+        new TokenizerAnnotator(),
+        new WordsToSentenceAnnotator(),
+      ],
+    );
+  }
+}
+
+export default CorefAnnotator;

--- a/src/simple/annotator/coref.spec.js
+++ b/src/simple/annotator/coref.spec.js
@@ -1,0 +1,20 @@
+import CorefAnnotator from './coref';
+
+describe('Annotator', () => {
+  let annotator;
+
+  describe('CorefAnnotator', () => {
+    beforeEach(() => {
+      annotator = new CorefAnnotator();
+    });
+
+    it('should have a proper pipeline', () => {
+      expect(annotator.pipeline()).to.deep.equal(['tokenize', 'ssplit', 'coref']);
+    });
+
+    it('should have the proper default options', () => {
+      expect(annotator.options()).to.deep.equal({
+      });
+    });
+  });
+});

--- a/src/simple/coref-chain.js
+++ b/src/simple/coref-chain.js
@@ -1,0 +1,104 @@
+import CorefMention from './coref-mention';
+
+/**
+ * @class
+ * @classdesc Class representing an CorefChain
+ */
+class CorefChain {
+  /**
+   * Create an CorefChain
+   * @param {Array.<CorefMention>} mentions
+   */
+  constructor(mentions) {
+    this._mentions = mentions;
+  }
+
+  /**
+   * Retrieves all the contained CorefMention instances
+   * @returns {Array.<CorefMention>} mentions
+   */
+  mentions() {
+    return this._mentions;
+  }
+
+  /**
+   * Retrieves a CorefMention at the index specified
+   * @param {number} index
+   * @returns {CorefMention} mention
+   */
+  mention(index) {
+    return this._mentions[index];
+  }
+
+  /**
+   * Retrieves the first representative mention
+   * @returns {CorefMention} mention
+   */
+  representative() {
+    return this._mentions.find(mention => mention.isRepresentativeMention());
+  }
+
+  /**
+   * Retrieves all the non-representative mentions
+   * @returns {Array.<CorefMention>} mentions
+   */
+  nonRepresentatives() {
+    return this._mentions.filter(mention => !mention.isRepresentativeMention());
+  }
+
+  /**
+   * Gets or sets a Document reference for the current coref-chain
+   * @param {Document} doc
+   * @returns {Document} doc
+   */
+  document(doc = null) {
+    if (doc) {
+      this._document = doc;
+    }
+
+    return this._document;
+  }
+
+  /**
+   * Update an instance of CorefChain with Document references to Sentence(s) and their Token(s)
+   * @param {Document} doc - a Document object, the same one used to generate corefs annotations
+   * @returns {CorefChain} chain - The current chain instance
+   */
+  fromDocument(doc) {
+    this._mentions.forEach((mention) => {
+      const sentence = doc.sentence(mention.sentNum() - 1);
+      const token = sentence.token(mention.startIndex() - 1);
+      mention.sentence(sentence);
+      mention.token(token);
+    });
+    return this;
+  }
+
+  /**
+   * Update an instance of CorefChain with data provided by a JSON
+   * @param {Array.<CorefMentionJSON>} data - A sentence corefs mentions chain, as 
+   *  returned by CoreNLP API service
+   * @returns {CorefChain} chain - The current chain instance
+   */
+  fromJSON(data) {
+    this._mentions = data.map(mention => CorefMention.fromJSON(mention));
+    return this;
+  }
+
+  toJSON() {
+    return [...this._mentions];
+  }
+
+  /**
+   * Get an instance of CorefChain from a given JSON of sentence corefs
+   * @param {Array.<CorefMentionJSON>} data - The sentence corefs data, as
+   *  returned by CoreNLP API service
+   * @returns {CorefChain} sentenchain - A new CorefChain instance
+   */
+  static fromJSON(data) {
+    const instance = new this();
+    return instance.fromJSON(data);
+  }
+}
+
+export default CorefChain;

--- a/src/simple/coref-chain.spec.js
+++ b/src/simple/coref-chain.spec.js
@@ -1,0 +1,24 @@
+import CorefChain from './coref-chain';
+
+describe('CorefChain', () => {
+  let chain;
+
+  beforeEach(() => {
+    chain = new CorefChain();
+  });
+
+  context('CorefChain interface', () => {
+    it('should follow the CorefChain contract', () => {
+      expect(chain).to.have.property('mentions').that.is.a('function');
+      expect(chain).to.have.property('mention').that.is.a('function');
+      expect(chain).to.have.property('representative').that.is.a('function');
+      expect(chain).to.have.property('nonRepresentatives').that.is.a('function');
+      expect(chain).to.have.property('document').that.is.a('function');
+      expect(chain).to.have.property('fromDocument').that.is.a('function');
+      expect(chain).to.have.property('fromJSON').that.is.a('function');
+    });
+
+    describe.skip('constructor', () => {
+    });
+  });
+});

--- a/src/simple/coref-mention.js
+++ b/src/simple/coref-mention.js
@@ -1,0 +1,165 @@
+/**
+ * A CorefMention.
+ * @typedef CorefMentionJSON
+ * @property {number} id - Mention ID
+ * @property {string} text - The text (literal word) of the mention
+ * @property {number} sentNum - 1-based index of the sentence containinng this mention
+ * @property {number} headIndex - 1-based index
+ * @property {number} startIndex - 1-based index
+ * @property {number} endIndex - 1-based index
+ * @property {boolean} isRepresentativeMention - Wehther the mention word is representative or not
+ * @property {("ANIMATE"|"INANIMATE"|"UNKNOWN")} animacy - Mention's animacy
+ * @property {("FEMALE"|"MALE"|"NEUTRAL"|"UNKNOWN")} gender - Gender of the mention
+ * @property {("SINGULAR"|"PLURAL"|"UNKNOWN")} number - Cardinality of the mention
+ * @property {("PRONOMINAL"|"NOMINAL"|"PROPER"|"LIST")} type - Mention type
+ * @property {Array} position - Position is a binary tuple of 
+ *    (sentence number, mention number in that sentence). This is used for indexing by mention.
+ * 
+ * @see {@link https://github.com/stanfordnlp/CoreNLP/blob/7cfaf869f9500da16b858ab1a2835234ae46f96e/src/edu/stanford/nlp/dcoref/CorefChain.java#L148}
+ * @see {@link https://github.com/stanfordnlp/CoreNLP/blob/master/src/edu/stanford/nlp/dcoref/Dictionaries.java} for enum definitions
+ */
+
+/**
+ * @class
+ * @classdesc Class representing an CorefMention
+ */
+class CorefMention {
+  /**
+   * Retrieves the mention ID
+   * @returns {string} id
+   */
+  id() {
+    return this._data.id;
+  }
+
+  /**
+   * Retrieves the mention text
+   * @returns {string} text
+   */
+  text() {
+    return this._data.text;
+  }
+
+  /**
+   * Retrieves the mention sentence number
+   * @see {@link CorefMention.sentence()} for simplicity
+   * @returns {number} sentNum
+   */
+  sentNum() {
+    return this._data.sentNum;
+  }
+
+  /**
+   * Retrieves the mention headIndex
+   * @returns {number} headIndex
+   */
+  headIndex() {
+    return this._data.headIndex;
+  }
+
+  /**
+   * Retrieves the mention startIndex
+   * @returns {number} startIndex
+   */
+  startIndex() {
+    return this._data.startIndex;
+  }
+
+  /**
+   * Retrieves the mention endIndex
+   * @returns {number} endIndex
+   */
+  endIndex() {
+    return this._data.endIndex;
+  }
+
+  /**
+   * Tells you if the mentions is representative or not
+   * @returns {boolean} isRepresentativeMention
+   */
+  isRepresentativeMention() {
+    return this._data.isRepresentativeMention;
+  }
+
+  /**
+   * Retrieves the mention animacy
+   * @returns {("ANIMATE"|"INANIMATE"|"UNKNOWN")} animacy
+   */
+  animacy() {
+    return this._data.animacy;
+  }
+
+  /**
+   * Retrieves the mention gender
+   * @returns {("FEMALE"|"MALE"|"NEUTRAL"|"UNKNOWN")} gender
+   */
+  gender() {
+    return this._data.gender;
+  }
+
+  /**
+   * Retrieves the mention number
+   * @returns {("SINGULAR"|"PLURAL"|"UNKNOWN")} number
+   */
+  number() {
+    return this._data.number;
+  }
+
+  /**
+   * Retrieves the mention type
+   * @returns {("PRONOMINAL"|"NOMINAL"|"PROPER"|"LIST")} type
+   */
+  type() {
+    return this._data.type;
+  }
+
+  /**
+   * Retrieves the mention's sentence container
+   * @returns {Sentence} sentence
+   */
+  sentence(sentence = null) {
+    if (sentence) {
+      this._sentence = sentence;
+    }
+
+    return this._sentence;
+  }
+
+  /**
+   * Retrieves the mention's associated token
+   * @returns {Token} token
+   */
+  token(token = null) {
+    if (token) {
+      this._token = token;
+    }
+
+    return this._token;
+  }
+
+  /**
+   * Update an instance of CorefMention with data provided by a JSON
+   * @param {CorefMentionJSON} data - The mention data, as returned by CoreNLP API service
+   * @returns {CorefMention} mention - The current mention instance
+   */
+  fromJSON(data) {
+    this._data = data;
+    return this;
+  }
+
+  toJSON() {
+    return { ...this._data };
+  }
+
+  /**
+   * Get an instance of CorefMention from a given JSON
+   * @param {CorefMentionJSON} data - The match data, as returned by CoreNLP API service
+   * @returns {CorefMention} mention - A new CorefMention instance
+   */
+  static fromJSON(data) {
+    const instance = new this();
+    return instance.fromJSON(data);
+  }
+}
+
+export default CorefMention;

--- a/src/simple/coref-mention.spec.js
+++ b/src/simple/coref-mention.spec.js
@@ -1,0 +1,30 @@
+import CorefMention from './coref-mention';
+
+describe('CorefMention', () => {
+  let mention;
+
+  beforeEach(() => {
+    mention = new CorefMention();
+  });
+
+  context('CorefMention interface', () => {
+    it('should follow the CorefMention contract', () => {
+      expect(mention).to.have.property('id').that.is.a('function');
+      expect(mention).to.have.property('text').that.is.a('function');
+      expect(mention).to.have.property('sentNum').that.is.a('function');
+      expect(mention).to.have.property('headIndex').that.is.a('function');
+      expect(mention).to.have.property('startIndex').that.is.a('function');
+      expect(mention).to.have.property('endIndex').that.is.a('function');
+      expect(mention).to.have.property('isRepresentativeMention').that.is.a('function');
+      expect(mention).to.have.property('animacy').that.is.a('function');
+      expect(mention).to.have.property('gender').that.is.a('function');
+      expect(mention).to.have.property('number').that.is.a('function');
+      expect(mention).to.have.property('type').that.is.a('function');
+      expect(mention).to.have.property('sentence').that.is.a('function');
+      expect(mention).to.have.property('token').that.is.a('function');
+    });
+
+    describe.skip('constructor', () => {
+    });
+  });
+});

--- a/src/simple/sentence.stub.json
+++ b/src/simple/sentence.stub.json
@@ -59,7 +59,8 @@
       "ner": "O",
       "originalText": "happy",
       "pos": "JJ",
-      "word": "happy"
+      "word": "happy",
+      "speaker": "PER0"
     },
     {
       "after": "",
@@ -71,7 +72,8 @@
       "ner": "O",
       "originalText": "cat",
       "pos": "NN",
-      "word": "cat"
+      "word": "cat",
+      "speaker": "PER0"
     }
   ]
 }

--- a/src/simple/token.js
+++ b/src/simple/token.js
@@ -149,6 +149,15 @@ class Token extends Annotable {
   }
 
   /**
+   * Get the annotated speaker for the current token
+   * @see {@link CorefAnnotator}
+   * @returns {string} speaker
+   */
+  speaker() {
+    return this._speaker;
+  }
+
+  /**
    * Get a JSON representation of the current token
    * @description
    * The following arrow function `data => Token.fromJSON(data).toJSON()` is idempontent, if
@@ -169,6 +178,7 @@ class Token extends Annotable {
       pos: this._pos,
       lemma: this._lemma,
       ner: this._ner,
+      speaker: this._speaker,
     };
   }
 
@@ -190,6 +200,7 @@ class Token extends Annotable {
     instance._pos = data.pos;
     instance._lemma = data.lemma;
     instance._ner = data.ner;
+    instance._speaker = data.speaker;
     return instance;
   }
 }

--- a/src/simple/token.spec.js
+++ b/src/simple/token.spec.js
@@ -120,6 +120,17 @@ describe('Token', () => {
       });
     });
 
+    describe('speaker', () => {
+      it('should return the Speaker given by the JSON API', () => {
+        const token2 = Token.fromJSON({
+          word: 'loren',
+          speaker: 'PER1',
+        });
+        expect(token2.speaker()).to.be.a('string');
+        expect(token2.speaker()).to.equals('PER1');
+      });
+    });
+
     describe('fromJSON / toJSON', () => {
       const tokenJSON = {
         index: 2,
@@ -132,6 +143,7 @@ describe('Token', () => {
         pos: 'NNP',
         lemma: 'loren',
         ner: 'PERSON',
+        speaker: 'PER0',
       };
 
       beforeEach(() => {
@@ -144,6 +156,7 @@ describe('Token', () => {
         expect(token.pos()).to.be.a('string').and.equals('NNP');
         expect(token.lemma()).to.be.a('string').and.equals('loren');
         expect(token.ner()).to.be.a('string').and.equals('PERSON');
+        expect(token.speaker()).to.be.a('string').and.equals('PER0');
       });
 
       it('should return back the same input json, but not the exact', () => {

--- a/test/corefs.json
+++ b/test/corefs.json
@@ -1,0 +1,1298 @@
+{
+    "corefs": {
+        "5": [
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 2,
+                "gender": "MALE",
+                "headIndex": 1,
+                "id": 0,
+                "isRepresentativeMention": true,
+                "number": "SINGULAR",
+                "position": [
+                    1,
+                    1
+                ],
+                "sentNum": 1,
+                "startIndex": 1,
+                "text": "George",
+                "type": "PROPER"
+            },
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 2,
+                "gender": "MALE",
+                "headIndex": 1,
+                "id": 2,
+                "isRepresentativeMention": false,
+                "number": "SINGULAR",
+                "position": [
+                    2,
+                    1
+                ],
+                "sentNum": 2,
+                "startIndex": 1,
+                "text": "He",
+                "type": "PRONOMINAL"
+            },
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 4,
+                "gender": "MALE",
+                "headIndex": 3,
+                "id": 5,
+                "isRepresentativeMention": false,
+                "number": "SINGULAR",
+                "position": [
+                    3,
+                    3
+                ],
+                "sentNum": 3,
+                "startIndex": 3,
+                "text": "he",
+                "type": "PRONOMINAL"
+            }
+        ],
+        "7": [
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 2,
+                "gender": "FEMALE",
+                "headIndex": 1,
+                "id": 6,
+                "isRepresentativeMention": true,
+                "number": "SINGULAR",
+                "position": [
+                    4,
+                    1
+                ],
+                "sentNum": 4,
+                "startIndex": 1,
+                "text": "Lisa",
+                "type": "PROPER"
+            },
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 12,
+                "gender": "FEMALE",
+                "headIndex": 11,
+                "id": 7,
+                "isRepresentativeMention": false,
+                "number": "SINGULAR",
+                "position": [
+                    4,
+                    2
+                ],
+                "sentNum": 4,
+                "startIndex": 11,
+                "text": "her",
+                "type": "PRONOMINAL"
+            }
+        ],
+        "9": [
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 2,
+                "gender": "UNKNOWN",
+                "headIndex": 1,
+                "id": 4,
+                "isRepresentativeMention": true,
+                "number": "SINGULAR",
+                "position": [
+                    3,
+                    2
+                ],
+                "sentNum": 3,
+                "startIndex": 1,
+                "text": "I",
+                "type": "PRONOMINAL"
+            },
+            {
+                "animacy": "ANIMATE",
+                "endIndex": 9,
+                "gender": "UNKNOWN",
+                "headIndex": 8,
+                "id": 9,
+                "isRepresentativeMention": false,
+                "number": "SINGULAR",
+                "position": [
+                    4,
+                    4
+                ],
+                "sentNum": 4,
+                "startIndex": 8,
+                "text": "I",
+                "type": "PRONOMINAL"
+            }
+        ]
+    },
+    "docDate": "2018-01-14T15:06:27",
+    "sentences": [
+        {
+            "basicDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 5,
+                    "dependentGloss": "person",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "George",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 3,
+                    "dependentGloss": "a",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 4,
+                    "dependentGloss": "good",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 6,
+                    "dependentGloss": ".",
+                    "governor": 5,
+                    "governorGloss": "person"
+                }
+            ],
+            "enhancedDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 5,
+                    "dependentGloss": "person",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "George",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 3,
+                    "dependentGloss": "a",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 4,
+                    "dependentGloss": "good",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 6,
+                    "dependentGloss": ".",
+                    "governor": 5,
+                    "governorGloss": "person"
+                }
+            ],
+            "enhancedPlusPlusDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 5,
+                    "dependentGloss": "person",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "George",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 3,
+                    "dependentGloss": "a",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 4,
+                    "dependentGloss": "good",
+                    "governor": 5,
+                    "governorGloss": "person"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 6,
+                    "dependentGloss": ".",
+                    "governor": 5,
+                    "governorGloss": "person"
+                }
+            ],
+            "index": 0,
+            "tokens": [
+                {
+                    "after": " ",
+                    "before": "",
+                    "characterOffsetBegin": 0,
+                    "characterOffsetEnd": 6,
+                    "index": 1,
+                    "lemma": "George",
+                    "ner": "PERSON",
+                    "originalText": "George",
+                    "pos": "NNP",
+                    "speaker": "PER0",
+                    "word": "George"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 7,
+                    "characterOffsetEnd": 9,
+                    "index": 2,
+                    "lemma": "be",
+                    "ner": "O",
+                    "originalText": "is",
+                    "pos": "VBZ",
+                    "speaker": "PER0",
+                    "word": "is"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 10,
+                    "characterOffsetEnd": 11,
+                    "index": 3,
+                    "lemma": "a",
+                    "ner": "O",
+                    "originalText": "a",
+                    "pos": "DT",
+                    "speaker": "PER0",
+                    "word": "a"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 12,
+                    "characterOffsetEnd": 16,
+                    "index": 4,
+                    "lemma": "good",
+                    "ner": "O",
+                    "originalText": "good",
+                    "pos": "JJ",
+                    "speaker": "PER0",
+                    "word": "good"
+                },
+                {
+                    "after": "",
+                    "before": " ",
+                    "characterOffsetBegin": 17,
+                    "characterOffsetEnd": 23,
+                    "index": 5,
+                    "lemma": "person",
+                    "ner": "O",
+                    "originalText": "person",
+                    "pos": "NN",
+                    "speaker": "PER0",
+                    "word": "person"
+                },
+                {
+                    "after": " ",
+                    "before": "",
+                    "characterOffsetBegin": 23,
+                    "characterOffsetEnd": 24,
+                    "index": 6,
+                    "lemma": ".",
+                    "ner": "O",
+                    "originalText": ".",
+                    "pos": ".",
+                    "speaker": "PER0",
+                    "word": "."
+                }
+            ]
+        },
+        {
+            "basicDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 4,
+                    "dependentGloss": "smart",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "He",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "really",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 5,
+                    "dependentGloss": ".",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                }
+            ],
+            "enhancedDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 4,
+                    "dependentGloss": "smart",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "He",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "really",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 5,
+                    "dependentGloss": ".",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                }
+            ],
+            "enhancedPlusPlusDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 4,
+                    "dependentGloss": "smart",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "He",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "really",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 5,
+                    "dependentGloss": ".",
+                    "governor": 4,
+                    "governorGloss": "smart"
+                }
+            ],
+            "index": 1,
+            "tokens": [
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 25,
+                    "characterOffsetEnd": 27,
+                    "index": 1,
+                    "lemma": "he",
+                    "ner": "O",
+                    "originalText": "He",
+                    "pos": "PRP",
+                    "speaker": "PER0",
+                    "word": "He"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 28,
+                    "characterOffsetEnd": 30,
+                    "index": 2,
+                    "lemma": "be",
+                    "ner": "O",
+                    "originalText": "is",
+                    "pos": "VBZ",
+                    "speaker": "PER0",
+                    "word": "is"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 31,
+                    "characterOffsetEnd": 37,
+                    "index": 3,
+                    "lemma": "really",
+                    "ner": "O",
+                    "originalText": "really",
+                    "pos": "RB",
+                    "speaker": "PER0",
+                    "word": "really"
+                },
+                {
+                    "after": "",
+                    "before": " ",
+                    "characterOffsetBegin": 38,
+                    "characterOffsetEnd": 43,
+                    "index": 4,
+                    "lemma": "smart",
+                    "ner": "O",
+                    "originalText": "smart",
+                    "pos": "JJ",
+                    "speaker": "PER0",
+                    "word": "smart"
+                },
+                {
+                    "after": " ",
+                    "before": "",
+                    "characterOffsetBegin": 43,
+                    "characterOffsetEnd": 44,
+                    "index": 5,
+                    "lemma": ".",
+                    "ner": "O",
+                    "originalText": ".",
+                    "pos": ".",
+                    "speaker": "PER0",
+                    "word": "."
+                }
+            ]
+        },
+        {
+            "basicDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 2,
+                    "dependentGloss": "heard",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "I",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 3,
+                    "dependentGloss": "he",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 4,
+                    "dependentGloss": "is",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 5,
+                    "dependentGloss": "also",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 6,
+                    "dependentGloss": "a",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 7,
+                    "dependentGloss": "great",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "ccomp",
+                    "dependent": 8,
+                    "dependentGloss": "son",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 9,
+                    "dependentGloss": ".",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                }
+            ],
+            "enhancedDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 2,
+                    "dependentGloss": "heard",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "I",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 3,
+                    "dependentGloss": "he",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 4,
+                    "dependentGloss": "is",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 5,
+                    "dependentGloss": "also",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 6,
+                    "dependentGloss": "a",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 7,
+                    "dependentGloss": "great",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "ccomp",
+                    "dependent": 8,
+                    "dependentGloss": "son",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 9,
+                    "dependentGloss": ".",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                }
+            ],
+            "enhancedPlusPlusDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 2,
+                    "dependentGloss": "heard",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "I",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 3,
+                    "dependentGloss": "he",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 4,
+                    "dependentGloss": "is",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 5,
+                    "dependentGloss": "also",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 6,
+                    "dependentGloss": "a",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 7,
+                    "dependentGloss": "great",
+                    "governor": 8,
+                    "governorGloss": "son"
+                },
+                {
+                    "dep": "ccomp",
+                    "dependent": 8,
+                    "dependentGloss": "son",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 9,
+                    "dependentGloss": ".",
+                    "governor": 2,
+                    "governorGloss": "heard"
+                }
+            ],
+            "index": 2,
+            "tokens": [
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 45,
+                    "characterOffsetEnd": 46,
+                    "index": 1,
+                    "lemma": "I",
+                    "ner": "O",
+                    "originalText": "I",
+                    "pos": "PRP",
+                    "speaker": "PER0",
+                    "word": "I"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 47,
+                    "characterOffsetEnd": 52,
+                    "index": 2,
+                    "lemma": "hear",
+                    "ner": "O",
+                    "originalText": "heard",
+                    "pos": "VBD",
+                    "speaker": "PER0",
+                    "word": "heard"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 53,
+                    "characterOffsetEnd": 55,
+                    "index": 3,
+                    "lemma": "he",
+                    "ner": "O",
+                    "originalText": "he",
+                    "pos": "PRP",
+                    "speaker": "PER0",
+                    "word": "he"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 56,
+                    "characterOffsetEnd": 58,
+                    "index": 4,
+                    "lemma": "be",
+                    "ner": "O",
+                    "originalText": "is",
+                    "pos": "VBZ",
+                    "speaker": "PER0",
+                    "word": "is"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 59,
+                    "characterOffsetEnd": 63,
+                    "index": 5,
+                    "lemma": "also",
+                    "ner": "O",
+                    "originalText": "also",
+                    "pos": "RB",
+                    "speaker": "PER0",
+                    "word": "also"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 64,
+                    "characterOffsetEnd": 65,
+                    "index": 6,
+                    "lemma": "a",
+                    "ner": "O",
+                    "originalText": "a",
+                    "pos": "DT",
+                    "speaker": "PER0",
+                    "word": "a"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 66,
+                    "characterOffsetEnd": 71,
+                    "index": 7,
+                    "lemma": "great",
+                    "ner": "O",
+                    "originalText": "great",
+                    "pos": "JJ",
+                    "speaker": "PER0",
+                    "word": "great"
+                },
+                {
+                    "after": "",
+                    "before": " ",
+                    "characterOffsetBegin": 72,
+                    "characterOffsetEnd": 75,
+                    "index": 8,
+                    "lemma": "son",
+                    "ner": "O",
+                    "originalText": "son",
+                    "pos": "NN",
+                    "speaker": "PER0",
+                    "word": "son"
+                },
+                {
+                    "after": "\n\n",
+                    "before": "",
+                    "characterOffsetBegin": 75,
+                    "characterOffsetEnd": 76,
+                    "index": 9,
+                    "lemma": ".",
+                    "ner": "O",
+                    "originalText": ".",
+                    "pos": ".",
+                    "speaker": "PER0",
+                    "word": "."
+                }
+            ]
+        },
+        {
+            "basicDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 6,
+                    "dependentGloss": "girl",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "Lisa",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "instead",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 4,
+                    "dependentGloss": "a",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 5,
+                    "dependentGloss": "sad",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 7,
+                    "dependentGloss": ",",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 8,
+                    "dependentGloss": "I",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "neg",
+                    "dependent": 9,
+                    "dependentGloss": "never",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "parataxis",
+                    "dependent": 10,
+                    "dependentGloss": "saw",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nmod:poss",
+                    "dependent": 11,
+                    "dependentGloss": "her",
+                    "governor": 12,
+                    "governorGloss": "happy"
+                },
+                {
+                    "dep": "dobj",
+                    "dependent": 12,
+                    "dependentGloss": "happy",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 13,
+                    "dependentGloss": ".",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                }
+            ],
+            "enhancedDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 6,
+                    "dependentGloss": "girl",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "Lisa",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "instead",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 4,
+                    "dependentGloss": "a",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 5,
+                    "dependentGloss": "sad",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 7,
+                    "dependentGloss": ",",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 8,
+                    "dependentGloss": "I",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "neg",
+                    "dependent": 9,
+                    "dependentGloss": "never",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "parataxis",
+                    "dependent": 10,
+                    "dependentGloss": "saw",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nmod:poss",
+                    "dependent": 11,
+                    "dependentGloss": "her",
+                    "governor": 12,
+                    "governorGloss": "happy"
+                },
+                {
+                    "dep": "dobj",
+                    "dependent": 12,
+                    "dependentGloss": "happy",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 13,
+                    "dependentGloss": ".",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                }
+            ],
+            "enhancedPlusPlusDependencies": [
+                {
+                    "dep": "ROOT",
+                    "dependent": 6,
+                    "dependentGloss": "girl",
+                    "governor": 0,
+                    "governorGloss": "ROOT"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 1,
+                    "dependentGloss": "Lisa",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "cop",
+                    "dependent": 2,
+                    "dependentGloss": "is",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "advmod",
+                    "dependent": 3,
+                    "dependentGloss": "instead",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "det",
+                    "dependent": 4,
+                    "dependentGloss": "a",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "amod",
+                    "dependent": 5,
+                    "dependentGloss": "sad",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 7,
+                    "dependentGloss": ",",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nsubj",
+                    "dependent": 8,
+                    "dependentGloss": "I",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "neg",
+                    "dependent": 9,
+                    "dependentGloss": "never",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "parataxis",
+                    "dependent": 10,
+                    "dependentGloss": "saw",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                },
+                {
+                    "dep": "nmod:poss",
+                    "dependent": 11,
+                    "dependentGloss": "her",
+                    "governor": 12,
+                    "governorGloss": "happy"
+                },
+                {
+                    "dep": "dobj",
+                    "dependent": 12,
+                    "dependentGloss": "happy",
+                    "governor": 10,
+                    "governorGloss": "saw"
+                },
+                {
+                    "dep": "punct",
+                    "dependent": 13,
+                    "dependentGloss": ".",
+                    "governor": 6,
+                    "governorGloss": "girl"
+                }
+            ],
+            "index": 3,
+            "tokens": [
+                {
+                    "after": " ",
+                    "before": "\n\n",
+                    "characterOffsetBegin": 78,
+                    "characterOffsetEnd": 82,
+                    "index": 1,
+                    "lemma": "Lisa",
+                    "ner": "PERSON",
+                    "originalText": "Lisa",
+                    "pos": "NNP",
+                    "speaker": "PER0",
+                    "word": "Lisa"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 83,
+                    "characterOffsetEnd": 85,
+                    "index": 2,
+                    "lemma": "be",
+                    "ner": "O",
+                    "originalText": "is",
+                    "pos": "VBZ",
+                    "speaker": "PER0",
+                    "word": "is"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 86,
+                    "characterOffsetEnd": 93,
+                    "index": 3,
+                    "lemma": "instead",
+                    "ner": "O",
+                    "originalText": "instead",
+                    "pos": "RB",
+                    "speaker": "PER0",
+                    "word": "instead"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 94,
+                    "characterOffsetEnd": 95,
+                    "index": 4,
+                    "lemma": "a",
+                    "ner": "O",
+                    "originalText": "a",
+                    "pos": "DT",
+                    "speaker": "PER0",
+                    "word": "a"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 96,
+                    "characterOffsetEnd": 99,
+                    "index": 5,
+                    "lemma": "sad",
+                    "ner": "O",
+                    "originalText": "sad",
+                    "pos": "JJ",
+                    "speaker": "PER0",
+                    "word": "sad"
+                },
+                {
+                    "after": "",
+                    "before": " ",
+                    "characterOffsetBegin": 100,
+                    "characterOffsetEnd": 104,
+                    "index": 6,
+                    "lemma": "girl",
+                    "ner": "O",
+                    "originalText": "girl",
+                    "pos": "NN",
+                    "speaker": "PER0",
+                    "word": "girl"
+                },
+                {
+                    "after": " ",
+                    "before": "",
+                    "characterOffsetBegin": 104,
+                    "characterOffsetEnd": 105,
+                    "index": 7,
+                    "lemma": ",",
+                    "ner": "O",
+                    "originalText": ",",
+                    "pos": ",",
+                    "speaker": "PER0",
+                    "word": ","
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 106,
+                    "characterOffsetEnd": 107,
+                    "index": 8,
+                    "lemma": "I",
+                    "ner": "O",
+                    "originalText": "I",
+                    "pos": "PRP",
+                    "speaker": "PER0",
+                    "word": "I"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 108,
+                    "characterOffsetEnd": 113,
+                    "index": 9,
+                    "lemma": "never",
+                    "ner": "O",
+                    "originalText": "never",
+                    "pos": "RB",
+                    "speaker": "PER0",
+                    "word": "never"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 114,
+                    "characterOffsetEnd": 117,
+                    "index": 10,
+                    "lemma": "see",
+                    "ner": "O",
+                    "originalText": "saw",
+                    "pos": "VBD",
+                    "speaker": "PER0",
+                    "word": "saw"
+                },
+                {
+                    "after": " ",
+                    "before": " ",
+                    "characterOffsetBegin": 118,
+                    "characterOffsetEnd": 121,
+                    "index": 11,
+                    "lemma": "she",
+                    "ner": "O",
+                    "originalText": "her",
+                    "pos": "PRP$",
+                    "speaker": "PER0",
+                    "word": "her"
+                },
+                {
+                    "after": "",
+                    "before": " ",
+                    "characterOffsetBegin": 122,
+                    "characterOffsetEnd": 127,
+                    "index": 12,
+                    "lemma": "happy",
+                    "ner": "O",
+                    "originalText": "happy",
+                    "pos": "JJ",
+                    "speaker": "PER0",
+                    "word": "happy"
+                },
+                {
+                    "after": "",
+                    "before": "",
+                    "characterOffsetBegin": 127,
+                    "characterOffsetEnd": 128,
+                    "index": 13,
+                    "lemma": ".",
+                    "ner": "O",
+                    "originalText": ".",
+                    "pos": ".",
+                    "speaker": "PER0",
+                    "word": "."
+                }
+            ]
+        }
+    ]
+}

--- a/test/corefs.txt
+++ b/test/corefs.txt
@@ -1,0 +1,28 @@
+TODO list:
+doc sentences' tokens' speaker property
+doc corefs object
+  key?
+  value: CorefChain
+
+
+
+Running on raw text:
+String text = ...;
+String[] args = new String[]{
+  "-props", "edu/stanford/nlp/hcoref/properties/zh-dcoref-default.properties"
+};
+
+
+Annotation document = new Annotation(text);
+Properties props = StringUtils.argsToProperties(args);
+StanfordCoreNLP corenlp = new StanfordCoreNLP(props);
+corenlp.annotate(document);
+
+
+HybridCorefAnnotator hcoref = new HybridCorefAnnotator(props);
+hcoref.annotate(document);
+
+
+Map corefChain = document.get(CorefChainAnnotation.class); 
+System.out.println(corefChain);
+


### PR DESCRIPTION
## Usage Example
```javascript
// NOTE: run with babel-node
import path from 'path';
import CoreNLP, { Properties, Pipeline, ConnectorServer } from '../src';

const props = new Properties();
props.setProperty('annotators', 'tokenize,ssplit,coref');
const doc = new CoreNLP.simple.Document(`
  George is a good person. He is really smart. I heard he is also a great son.
  Lisa is instead a sad girl, I never saw her happy.
`);
const pipeline = new Pipeline(props, 'English');

pipeline.annotate(doc)
  .then(doc => {
    const corefChains = doc.corefs();
    corefChains.forEach(chain => {
      console.log('representative ->', chain.representative().token().word());
      chain.nonRepresentatives().forEach(mention => {
        console.log(' ref ->', mention.token().word(), mention.gender(), mention.number());
      });
    });
  })
  .catch(err => {
    console.log('err', err);
  });

/*
OUTPUT:
representative -> George
 ref -> He MALE SINGULAR
 ref -> he MALE SINGULAR
representative -> Lisa
 ref -> her FEMALE SINGULAR
representative -> I
 ref -> I UNKNOWN SINGULAR
*/
```