### PR TITLE
Added ability to pass basic auth credentials via POST requests.

### DIFF
--- a/src/connector/connector-server.js
+++ b/src/connector/connector-server.js
@@ -2,6 +2,10 @@ import rp from 'request-promise-native';
 
 const config = {
   dsn: 'http://localhost:9000',
+  auth: {
+    user: null,
+    pass: null,
+  },
 };
 
 /**
@@ -71,6 +75,13 @@ class ConnectorServer {
       body: text,
       json: true,
     };
+
+    if (config.auth.user) {
+      rpOpts.auth = {
+        user: config.auth.user,
+        pass: config.auth.pass,
+      };
+    }
 
     return this._rp(rpOpts);
   }


### PR DESCRIPTION
Added an option to POST request that enables users to pass basic-auth parameters. Users can now execute the following code when using node-corenlp package:
```
const connector = new CoreNLP.ConnectorServer({
    dsn: 'http://some_ip:port',
    auth: {
        user: 'username',
        pass: 'password'
    }
});
```
