### PR TITLE
prevent unknown or misspelled annotators from being added to the annotator-array

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -217,7 +217,7 @@ class Pipeline {
   _getAnnotators() {
     return this._getAnnotatorsKeys()
       .reduce((acc, annotatorKey) => {
-        if (ANNOTATORS_BY_KEY.hasOwnProperty(annotatorKey)) {
+        if (Object.prototype.hasOwnProperty.call(ANNOTATORS_BY_KEY, annotatorKey)) {
           acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
         }
         else {

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -175,7 +175,6 @@ class Pipeline {
     return annotable;
   }
 
-
   /**
    * @private
    * @description
@@ -215,16 +214,18 @@ class Pipeline {
    * @returns {Array.<Annotator>} annotators - those set for this pipeline
    */
   _getAnnotators() {
-    return this._getAnnotatorsKeys()
-      .reduce((acc, annotatorKey) => {
-        if (Object.prototype.hasOwnProperty.call(ANNOTATORS_BY_KEY, annotatorKey)) {
-          acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
-        }
-        else {
-          console.log(`Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`);
-        }
-        return acc;
-      }, []);
+    return this._getAnnotatorsKeys().reduce((acc, annotatorKey) => {
+      if (
+        Object.prototype.hasOwnProperty.call(ANNOTATORS_BY_KEY, annotatorKey)
+      ) {
+        acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
+      } else {
+        console.log(
+          `Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`
+        );
+      }
+      return acc;
+    }, []);
   }
 
   /**
@@ -243,6 +244,5 @@ class Pipeline {
       }), {});
   }
 }
-
 
 export default Pipeline;

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -214,16 +214,13 @@ class Pipeline {
    * @returns {Array.<Annotator>} annotators - those set for this pipeline
    */
   _getAnnotators() {
-    return this._getAnnotatorsKeys().reduce((acc, annotatorKey) => {
-      if (
-        Object.prototype.hasOwnProperty.call(ANNOTATORS_BY_KEY, annotatorKey)
-      ) {
-        acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
-      } else {
-        console.log(`Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`);
-      }
-      return acc;
-    }, []);
+    return this._getAnnotatorsKeys()
+      .map((annotatorKey) => {
+        if (!Object.prototype.hasOwnProperty.call(ANNOTATORS_BY_KEY, annotatorKey)) {
+          throw new Error(`Annotator "${annotatorKey}" doesn't exist or is not supported.`);
+        }
+        return ANNOTATORS_BY_KEY[annotatorKey];
+      });
   }
 
   /**

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -216,7 +216,15 @@ class Pipeline {
    */
   _getAnnotators() {
     return this._getAnnotatorsKeys()
-      .map(annotatorKey => ANNOTATORS_BY_KEY[annotatorKey]);
+      .reduce((acc, annotatorKey) => {
+        if (ANNOTATORS_BY_KEY.hasOwnProperty(annotatorKey)) {
+          acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
+        }
+        else {
+          console.log(`Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`);
+        }
+        return acc;
+      }, []);
   }
 
   /**

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -220,9 +220,7 @@ class Pipeline {
       ) {
         acc.push(ANNOTATORS_BY_KEY[annotatorKey]);
       } else {
-        console.log(
-          `Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`
-        );
+        console.log(`Annotator "${annotatorKey}" doesn't exist or is not supported. Removing it from the pipeline.`);
       }
       return acc;
     }, []);


### PR DESCRIPTION
Hi,
thanks for creating this wrapper! I like it a lot. :) 

When I recently tried to use it with the ["openie" annotator](https://stanfordnlp.github.io/CoreNLP/openie.html) the program threw an unhandled exception. It seems like Annotators that are valid for CoreNLP but non-existend in ANNOTATORS_BY_KEY will add an undefined element to the annotator-list, causing problems down the line.

To reproduce, just add openie to the list of annotators.

I added a check to prevent that and added logging for the user. 

This is my first pull request, so please let me know if you spot any mistakes I've made. 