### PR TITLE
fix: npm run lint and test throw error on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "build": "gulp build",
     "build:browser": "gulp build:browser",
     "prepublish": "npm run lint && npm run test && npm run compile",
-    "lint": "eslint 'src/**/*.js' 'test/*.js'",
+    "lint": "eslint \"src/**/*.js\" \"test/*.js\"",
     "lint:fix": "npm run lint -- --fix",
-    "test": "nyc --reporter=html --reporter=text mocha test/setup.js --sort 'src/**/*.spec.js' --compilers js:babel-core/register --timeout 30000",
+    "test": "nyc --reporter=html --reporter=text mocha test/setup.js --sort \"src/**/*.spec.js\" --compilers js:babel-core/register --timeout 30000",
     "test:watch": "npm run test -- --watch",
     "doc": "DEBUG=gulp-jsdoc3 gulp doc"
   },


### PR DESCRIPTION
`npm run lint` and `npm run test` worked well under linux but didnt do anything on my windows-machine. Apparently the quotes are being treated as part of the pattern in windows.
https://github.com/mochajs/mocha/issues/2895#issuecomment-340386109

The PR fixed it for powershell on the windows machine. But I couldnt test yet, if it breaks testing in bash.