### PR TITLE
Updated path to request-promise-native to /dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "child-process-promise": false,
     "load-json-file": false,
     "request": false,
-    "request-promise-native": "./src/polyfills/request-promise-native.js",
+    "request-promise-native": "./dist/polyfills/request-promise-native.js",
     "tmp-file": false
   },
   "scripts": {


### PR DESCRIPTION
Working on a react app and I get an error that request-promise-native from corenlp cannot be resolved. This can be fixed by changing the path to the package under 'browser' from /src to /dist