### PR TITLE
Updating scripts to reflect examples and use English

### DIFF
--- a/scripts/corenlp-download
+++ b/scripts/corenlp-download
@@ -4,8 +4,8 @@
 
 mkdir `dirname $0`/../corenlp; \
 pushd `dirname $0`/../corenlp; \
-curl -O https://nlp.stanford.edu/software/stanford-spanish-corenlp-2017-06-09-models.jar; \
+curl -O https://nlp.stanford.edu/software/stanford-english-corenlp-2017-06-09-models.jar; \
 curl -O https://nlp.stanford.edu/software/stanford-corenlp-full-2017-06-09.zip; \
 unzip stanford-corenlp-full-2017-06-09.zip && rm stanford-corenlp-full-2017-06-09.zip; \
-mv stanford-spanish-corenlp-2017-06-09-models.jar stanford-corenlp-full-2017-06-09; \
+mv stanford-english-corenlp-2017-06-09-models.jar stanford-corenlp-full-2017-06-09; \
 popd

--- a/scripts/corenlp-server
+++ b/scripts/corenlp-server
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Start CoreNLP Server (spanish setup)
+# Start CoreNLP Server (english setup)
 
 if [ -f `dirname $0`/../corenlp/stanford-corenlp-full-2017-06-09/build.xml ]; then
   java -Xmx4g \
     -cp "`dirname $0`/../corenlp/stanford-corenlp-full-2017-06-09/*" \
     edu.stanford.nlp.pipeline.StanfordCoreNLPServer \
-    -serverProperties StanfordCoreNLP-spanish.properties \
+    -serverProperties StanfordCoreNLP-english.properties \
     -port 9000 \
     -timeout 30000
 else

--- a/scripts/corenlp-server
+++ b/scripts/corenlp-server
@@ -6,7 +6,7 @@ if [ -f `dirname $0`/../corenlp/stanford-corenlp-full-2017-06-09/build.xml ]; th
   java -Xmx4g \
     -cp "`dirname $0`/../corenlp/stanford-corenlp-full-2017-06-09/*" \
     edu.stanford.nlp.pipeline.StanfordCoreNLPServer \
-    -serverProperties StanfordCoreNLP-english.properties \
+    # -serverProperties StanfordCoreNLP-english.properties \ # doesn't work for english properties
     -port 9000 \
     -timeout 30000
 else


### PR DESCRIPTION
Reflecting changes from conversation in https://github.com/gerardobort/node-corenlp/issues/45. I think these changes to the scripts make sense since most package users will probably be using English, and more importantly it's confusing because the example is set up for English.